### PR TITLE
Enable `comma-dangle` rule for multiline

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = {
 	rules: {
 		'comma-dangle': [
 			'error',
-			'never'
+			'always-multiline'
 		],
 		'for-direction': 'error',
 		'getter-return': 'error',


### PR DESCRIPTION
Closes https://github.com/xojs/xo/issues/369, from which I copy why this would be good.

Forget code style preconceptions for a moment and let's see some practical reasons.

# Better editability

<table>
<th>Move items freely
<th>Remove items freely
<th>Easily edit multiple lines
<tr valign=top>
<td>

![move](https://user-images.githubusercontent.com/1402241/30582996-dba1415c-9d4f-11e7-97ba-4f058e1fddb7.gif)

<td>

![remove](https://user-images.githubusercontent.com/1402241/30583050-07b9a87e-9d50-11e7-89fc-8ab4cff6b20f.gif)

<td>

![multi-line actions](https://user-images.githubusercontent.com/1402241/30582858-5cbd1564-9d4f-11e7-8154-3db0c894f167.gif)

</table>

# Less noisy diffs

_Note:_ This problem is particularly visible on real code that's 40+ cols long. 


<table>
<tr>
<th>Before
<th>After

<tr valign=top>
<td>

``` js
[
    "one",
    "two"
]
```

add "three":

``` diff
[
    "one",
-   "two"
+   "two",
+   "three",
]
```

<td>

``` js
[
    "one",
    "two",
]
```

add "three":

``` diff
[
    "one",
    "two",
+   "three",
]
```

</table>

Does it not bother you or has your brain learned to block it out?

This PR lets you focus on a single changed line instead of 3. That's 66.6% less noise<em>!</em>

# Historical reason: IE isn't a thing anymore

ESLint 3.0.0 [disabled this rule](http://eslint.org/docs/user-guide/migrating-to-3.0.0#changes-to-eslintrecommended) in their recommended config:

> [comma-dangle](http://eslint.org/docs/rules/comma-dangle) used to be recommended because Internet Explorer 8 and earlier threw a syntax error when it found a dangling comma on object literal properties. However, [Internet Explorer 8 was end-of-lifed](https://www.microsoft.com/en-us/WindowsForBusiness/End-of-IE-support) in January 2016 and all other active browsers allow dangling commas. As such, we consider dangling commas to now be a stylistic issue instead of a possible error.

Are we holding onto this because that's what we were taught to do when Gmail still had 1 GB of free space?

# Bonus: ES2017 just extended support

Dangling commas are supported in arrays, object, imports, exports, and now in [function parameters](https://pawelgrzybek.com/trailing-comma-in-ecmascript2017-function-parameter-list/) since ES2017.

# Bonus: Prettier, Airbnb

It's also a default of [Prettier](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEBtA5AGQgJzgWwAIBLABwGcBXIgEwgBtd0Aadc4mQgQ3zk8ijk4YeDEo4W6LjTLF2YYlADmhOPQ4A6SQHkZnLpU4AzSko7oAuiGYgIpGMWjlkoLjhwQA7gAU3CZyhc9J5cAJ7ONgBGOFxgANZ8AMqksYpKyDA4lHA2ABYw+PQA6rkccOQpYHCJ-hzEAG4cocjg5BEgikI4MN4xSvhcyEZBQjYAVuQAHgBCMfFJPHCYinBDIzkgE5OJafRwAIqUEPBr9KMgKThdLZFckWrWFziKMEXENDC5yAAcAAw2pA8QiKMVILUB5TgOHqqxsAEcjvBenYAiAuOQALRQOBwGi4x54BHEPC9Lj9QZIYZnDZCfDEDJZGm7A6I1aU9Y2GB3N4fL5IABMnJixHUygAwhB8AMWuUAKyPShCAAqdwCVPO9WyAEkoHjYIkwM97ABBXWJGChPanIQAXxtQA) and [Airbnb’s shared config](https://github.com/airbnb/javascript/blob/06b3ab11d9a443ff46f052dd00375e271e5146e6/packages/eslint-config-airbnb-base/rules/style.js), two of the most common configurations. 

 I'm not saying that we should do it _just because they do it_ but this means more people are used to seeing them as well.

---

Now, I get it that this will bring a lot of changes to existing repos, but... `xo --fix` 🎉 