### PR TITLE
Add arrow-body-style rule

### DIFF
--- a/esnext.js
+++ b/esnext.js
@@ -4,6 +4,7 @@ const path = require('path');
 module.exports = {
 	extends: path.join(__dirname, 'index.js'),
 	rules: {
+		'arrow-body-style': 'error',
 		'no-var': 'error',
 		'object-shorthand': [
 			'error',


### PR DESCRIPTION
We have prefer-arrow-callback, which corrects `foo(function (x) { return x; })` to `foo(x => { return x; })`.  [arrow-body-style](https://eslint.org/docs/rules/arrow-body-style) further corrects this to the cleaner `foo(x => x)`.