### PR TITLE
Disable tabs except for indentation

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,12 @@ module.exports = {
 		'no-regex-spaces': 'error',
 		'no-setter-return': 'error',
 		'no-sparse-arrays': 'error',
+		'no-tabs': [
+			'error',
+			{
+				allowIndentationTabs: true
+			}
+		],
 		'no-template-curly-in-string': 'error',
 		'no-unreachable': 'error',
 		'no-unreachable-loop': 'error',


### PR DESCRIPTION
I saw `const•two•=→2` pass linting a couple of times, most recently: https://github.com/sindresorhus/refined-github/pull/3621#pullrequestreview-510795998

<img width="270" alt="" src="https://user-images.githubusercontent.com/1402241/96323237-dc1edb00-0fe1-11eb-8b44-e18cdd7eaf53.png">

[no-tabs](https://eslint.org/docs/rules/no-tabs) appears to be correct rule to catch this