### PR TITLE
Remove unnecessary `no-restricted-syntax` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -369,10 +369,6 @@ module.exports = {
 		],
 		'no-negated-condition': 'error',
 		'no-new-object': 'error',
-		'no-restricted-syntax': [
-			'error',
-			'WithStatement'
-		],
 		'no-whitespace-before-property': 'error',
 		'no-trailing-spaces': 'error',
 		'no-unneeded-ternary': 'error',


### PR DESCRIPTION
The `no-with` rule is also enabled in XO, causing this specification of `no-restricted-syntax` to be redundant.

https://github.com/xojs/eslint-config-xo/blob/ce11c9f3a59b71b30f166b5cc3f48bd72f889cab/index.js#L180