### PR TITLE
Remove out-of-date note about config overrides

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ Here are some reason why you should use the [XO CLI](https://github.com/xojs/xo)
 - No need to specify file paths to lint. It will lint all JS files except [commonly ignored paths](https://github.com/xojs/xo#ignores).
 - Super simple to add XO to a project with [`$ npm init xo`](https://github.com/xojs/create-xo).
 - Specify `indent` and `semicolon` preferences easily without messing with the rule config.
-- Config/rule overrides per files/globs. *(ESLint still doesn't support this)*
+- Config/rule overrides per files/globs.
 - Can open all files with errors at the correct line in your editor. *(See the `--open` flag)*
 - The [editor plugins](https://github.com/xojs/xo#editor-plugins) are IMHO better than the ESLint ones. *(Subjective)*
 


### PR DESCRIPTION
Removed as per https://github.com/xojs/xo/blob/main/readme.md?plain=1#L28.

By the way, I think it might be nice if the section is synced with https://github.com/xojs/xo#highlights 👀