### PR TITLE
Avoid explicit return arrows in `object-shorthand` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -542,6 +542,9 @@ module.exports = {
 		'object-shorthand': [
 			'error',
 			'always',
+			{
+				avoidExplicitReturnArrows: true,
+			}
 		],
 		'prefer-arrow-callback': [
 			'error',


### PR DESCRIPTION
Enable [`avoidExplicitReturnArrows`](https://eslint.org/docs/rules/object-shorthand#avoidexplicitreturnarrows) in the `object-shorthand` rule.

This is a breaking change