### PR TITLE
Enforce single-quotes for JSX

### DIFF
--- a/index.js
+++ b/index.js
@@ -326,7 +326,7 @@ module.exports = {
 				SwitchCase: 1,
 			},
 		],
-		'jsx-quotes': 'error',
+		'jsx-quotes': ['error', 'prefer-single'],
 		'key-spacing': [
 			'error',
 			{

--- a/index.js
+++ b/index.js
@@ -326,7 +326,10 @@ module.exports = {
 				SwitchCase: 1,
 			},
 		],
-		'jsx-quotes': ['error', 'prefer-single'],
+		'jsx-quotes': [
+			'error',
+			'prefer-single'
+		],
 		'key-spacing': [
 			'error',
 			{


### PR DESCRIPTION
The quotes for strings and string values of JSX attributes should both be single:

```js
const foo = 'bar';

<a href='https://example.com'>foo</a>
```

vs the current configuration which enforces different styles in the same file:

```js
const foo = 'bar';

<a href="https://example.com">foo</a>
```

What do you think?