### PR TITLE
Enable rule `sort-imports` for members

### DIFF
--- a/index.js
+++ b/index.js
@@ -475,6 +475,12 @@ module.exports = {
 			'error',
 			'always',
 		],
+		'sort-imports': [
+			'error',
+			{
+				ignoreDeclarationSort: true,
+			},
+		],
 		'space-before-blocks': [
 			'error',
 			'always',


### PR DESCRIPTION
There is no reason to not sort import members.

This is just an idea. Feel free to close if you disagree. :)