### PR TITLE
Enable permissive `max-len` and `max-lines` as warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -409,11 +409,18 @@ module.exports = {
 		'max-depth': 'warn',
 		'max-len': [
 			'warn',
-			200,
+			{
+				code: 200,
+				ignoreComments: true,
+				ignoreUrls: true
+			},
 		],
 		'max-lines': [
 			'warn',
-			2000,
+			{
+				max: 2000,
+				skipComments: true,
+			},
 		],
 		'max-nested-callbacks': [
 			'warn',

--- a/index.js
+++ b/index.js
@@ -387,7 +387,7 @@ module.exports = {
 		],
 		'max-lines': [
 			'warn',
-			1000,
+			2000,
 		],
 		'max-nested-callbacks': [
 			'warn',

--- a/index.js
+++ b/index.js
@@ -414,7 +414,7 @@ module.exports = {
 			{
 				code: 200,
 				ignoreComments: true,
-				ignoreUrls: true
+				ignoreUrls: true,
 			},
 		],
 		'max-lines': [

--- a/index.js
+++ b/index.js
@@ -381,6 +381,14 @@ module.exports = {
 		// ],
 
 		'max-depth': 'warn',
+		'max-len': [
+			'warn',
+			200,
+		],
+		'max-lines': [
+			'warn',
+			1000,
+		],
 		'max-nested-callbacks': [
 			'warn',
 			4,

--- a/index.js
+++ b/index.js
@@ -420,7 +420,7 @@ module.exports = {
 		'max-lines': [
 			'warn',
 			{
-				max: 2000,
+				max: 1500,
 				skipComments: true,
 			},
 		],


### PR DESCRIPTION
- Closes https://github.com/xojs/xo/issues/738

I think it might make sense to enable them as warning to look at the pushback without creating too much trouble. 

I think 200ch is a good upper limit, but I'm not sure about "1000 lines", especially in files with inline documentation and licensing.

https://eslint.org/docs/v8.x/rules/max-lines
https://eslint.org/docs/v8.x/rules/max-len