### PR TITLE
Allow class fields with no blank lines between

### DIFF
--- a/index.js
+++ b/index.js
@@ -374,11 +374,24 @@ module.exports = {
 		],
 		'lines-between-class-members': [
 			'error',
-			'always',
 			{
-				// Workaround to allow class fields to not have lines between them.
-				// TODO: Get ESLint to add an option to ignore class fields.
-				exceptAfterSingleLine: true,
+				enforce: [
+					{
+						blankLine: 'always',
+						prev: '*',
+						next: 'method',
+					},
+					{
+						blankLine: 'always',
+						prev: 'method',
+						next: 'field',
+					},
+					{
+						blankLine: 'never',
+						prev: 'field',
+						next: 'field',
+					},
+				],
 			},
 		],
 		'logical-assignment-operators': [


### PR DESCRIPTION
The `enforce` option has been added to `lines-between-class-members` rule of ESLint in v8.49.0 (see the [ESLint changelog](https://github.com/eslint/eslint/blob/main/CHANGELOG.md)). Currently the lowest ESLint version is 8.56.0.