### PR TITLE
Revert "Add option to `no-extra-boolean-cast`"

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,12 +40,14 @@ module.exports = {
 		],
 		'no-empty-static-block': 'error',
 		'no-ex-assign': 'error',
-		'no-extra-boolean-cast': [
-			'error',
-			{
-				enforceForInnerExpressions: true
-			},
-		],
+		'no-extra-boolean-cast': 'error',
+		// Disabled because of https://github.com/xojs/eslint-config-xo/pull/87
+		// 'no-extra-boolean-cast': [
+		// 	'error',
+		// 	{
+		// 		enforceForInnerExpressions: true
+		// 	},
+		// ],
 		// Disabled because of https://github.com/eslint/eslint/issues/6028
 		// 'no-extra-parens': [
 		// 	'error',


### PR DESCRIPTION
I don't know what's up, but it failed on `main` when it was merged and it's still failing today in #26.

```
ESLint: 8.57.0

Error: .eslintrc.cjs:
	Configuration for rule "no-extra-boolean-cast" is invalid:
	Value {"enforceForInnerExpressions":true,"enforceForLogicalOperands":false} should NOT have additional properties.
```

Nobody complained about it on ESLint's repo either: https://github.com/eslint/eslint/issues?q=%22no-extra-boolean-cast%22