### PR TITLE
Add v8 to the `ignorePattern` for `capitalized-comments`

### DIFF
--- a/index.js
+++ b/index.js
@@ -302,7 +302,7 @@ const rules = {
 		{
 			// You can also ignore this rule by wrapping the first word in quotes.
 			// c8 => https://github.com/bcoe/c8
-			ignorePattern: /pragma|ignore|prettier-ignore|webpack\w+:|c8|type-coverage:/.source,
+			ignorePattern: /pragma|ignore|prettier-ignore|webpack\w+:|c8|v8|type-coverage:/.source,
 			ignoreInlineComments: true,
 			ignoreConsecutiveComments: true,
 		},


### PR DESCRIPTION
closes: https://github.com/xojs/xo/issues/765

V8 is Google's JS engine and allows for [native code coverage](https://v8.dev/blog/javascript-code-coverage). But in order to ignore lines from being gathered the string must be lowercase.

```diff
- /* V8 ignore next 3 */ <--- as the default capitalized-comments rule would change
+ /* v8 ignore next 3 */
```

Source: https://vitest.dev/guide/coverage.html#ignoring-code
Further context: https://eslint.org/docs/latest/rules/capitalized-comments