### PR TITLE
Support codespell in `capitalized-comments`

### DIFF
--- a/index.js
+++ b/index.js
@@ -308,7 +308,7 @@ const rules = {
 		{
 			// You can also ignore this rule by wrapping the first word in quotes.
 			// c8 => https://github.com/bcoe/c8
-			ignorePattern: /pragma|ignore|prettier-ignore|biome-ignore|webpack\w+:|c8|v8|type-coverage:/.source,
+			ignorePattern: /pragma|ignore|prettier-ignore|biome-ignore|codespell:ignore|webpack\w+:|c8|v8|type-coverage:/.source,
 			ignoreInlineComments: true,
 			ignoreConsecutiveComments: true,
 		},


### PR DESCRIPTION
https://github.com/codespell-project/codespell#inline-ignore

- like https://github.com/xojs/eslint-config-xo/pull/90