### PR TITLE
Disable unicorn/require-array-sort-compare in favor of TS version

### DIFF
--- a/source/typescript-rules.js
+++ b/source/typescript-rules.js
@@ -549,6 +549,7 @@ export const typescriptRules = {
 		},
 	],
 	'@typescript-eslint/return-await': 'error',
+	'unicorn/require-array-sort-compare': 'off',
 	'@typescript-eslint/require-array-sort-compare': [
 		'error',
 		{


### PR DESCRIPTION
`unicorn/require-array-sort-compare` is less precise than `@typescript-eslint/require-array-sort-compare`. Disable the former when the latter is used.

- Fixes #104.