### PR TITLE
Disable `@html-eslint/require-closing-tags` under `prettier`

### DIFF
--- a/source/html.js
+++ b/source/html.js
@@ -14,6 +14,7 @@ const prettierConflictingRules = [
 	'@html-eslint/no-multiple-empty-lines',
 	'@html-eslint/no-trailing-spaces',
 	'@html-eslint/quotes',
+	'@html-eslint/require-closing-tags',
 ];
 
 export function getHtmlConfig({space = false, prettier = false} = {}) {


### PR DESCRIPTION
- Fixes #110.